### PR TITLE
Delete and recreate the git config file before deploy

### DIFF
--- a/jobs/eqsurveyrunner.groovy
+++ b/jobs/eqsurveyrunner.groovy
@@ -7,6 +7,7 @@ job('Deploy Survey Runner') {
        githubPush()
   }
   steps {
+    shell('rm ./.ebextensions/git-revision.config')
     shell('cat << EOF >> ./.ebextensions/git-revision.config\n\noption_settings:\n  - option_name: EQ_GIT_REF\n    value: ${GIT_COMMIT}\nEOF')
     shell('npm install')
     shell('npm run compile')


### PR DESCRIPTION
**What**
The zero downtime deployments for the survey runner are failing on Jenkins. It turns out it's because the git-revision file was being appended to rather than recreated, so when the second environment was being spun up it failed to deploy. This change fixes this problem by deleting the file and then recreating it.

**How to test**
1. Visit the production Jenkins server
2. Point the DSL seed job at this branch
3. Re-run the DSL seed job (this will recreate the Deploy Survey Runner Job)
4. Check the Deploy Survey Runner job has the additional delete step
5. Run the Deploy Survey Runner job and check the zero downtime deployment passes successfully.

**Who can review**
Anyone apart from @warrenbailey
