### PR TITLE
Clean node cache prior to deployment

### DIFF
--- a/jobs/eqsurveyrunner.groovy
+++ b/jobs/eqsurveyrunner.groovy
@@ -9,6 +9,8 @@ job('Deploy Survey Runner') {
   steps {
     shell('rm ./.ebextensions/git-revision.config')
     shell('cat << EOF >> ./.ebextensions/git-revision.config\n\noption_settings:\n  - option_name: EQ_GIT_REF\n    value: ${GIT_COMMIT}\nEOF')
+    shell('rm -rf node_modules')
+    shell('npm cache clean')
     shell('npm install')
     shell('npm run compile')
     shell('mkdir -p keys')


### PR DESCRIPTION
**What**
Clear the node cache before deployment, this should ensure the latest static files are built and available for the application.

**How to test**
1. Visit the jenkins server on pre-prod (http://deploy-preprod.eq.ons.digital:8080)
2. Regenerate the jobs using the DSL seed job
3. Enter the correct AWS credential on the Deploy Survey runner job.
4. Enter the correct Elastic beanstalk application and environment name
5. Run the build and check the application is deployment successfully.

**Who can review**
Anyone apart from @warrenbailey
