### PR TITLE
Update the Terraform env var for survey launcher URL

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -842,7 +842,7 @@ jobs:
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
       TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
-      TF_VAR_survey_launcher_url: https://preprod-new-surveys.eq.ons.digital
+      TF_VAR_survey_launcher_url: https://preprod-new-surveys-launch.eq.ons.digital
       TF_VAR_application_cidrs: [10.30.21.192/28,10.30.21.208/28,10.30.21.224/28]
     config:
       platform: linux


### PR DESCRIPTION
## Description
The eq.yml had the wrong environment variable set for survey launcher url, this broke questionnaire preview in Author.
This PR corrects the survey launcher URL.