### PR TITLE
Wait for correct versions to be deployed on PreProd

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -653,6 +653,9 @@ jobs:
     - get: eq-survey-register
       passed: [staging-deploy]
       trigger: true
+    - get: eq-terraform
+      passed: [staging-deploy]
+      trigger: true
     - get: eq-survey-runner-deploy
       passed: [staging-deploy]
       trigger: true
@@ -960,11 +963,116 @@ jobs:
           -var author_tag=$author_tag \
           -var author_api_tag=$author_api_tag \
           -var publisher_tag=$publisher_tag
+
+  - task: Wait for Deployed Survey Runner
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          survey_runner_tag=$(cat eq-survey-runner/.git/HEAD | xargs echo -n)
+          while [[ "$(curl -s https://preprod-new-surveys.eq.ons.digital/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-runner'
+        attachments:
+          - pretext: PreProd Survey Runner Deploy Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+  - task: Wait for Deployed Author API
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-api
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          author_api_tag=$(cat eq-author-api/.git/HEAD | xargs echo -n)
+          while [[ "$(curl -s https://preprod-author-api.eq.ons.digital/status)" != *"$author_api_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+          - pretext: PreProd Author API Deploy Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+  - task: Wait for Deployed Author
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          author_tag=$(cat eq-author/.git/HEAD | xargs echo -n)
+          while [[ "$(curl -s https://preprod-author.eq.ons.digital/status.json)" != *"$author_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+          - pretext: PreProd Author Deploy Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+  - task: Wait for Deployed Publisher
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-publisher
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          publisher_tag=$(cat eq-publisher/.git/HEAD | xargs echo -n)
+          while [[ "$(curl -s https://preprod-publisher.eq.ons.digital/status)" != *"$publisher_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+          - pretext: PreProd Publisher Deploy Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
   - put: slack-alert
     params:
       channel: '#eq-runner'
       attachments:
-        - pretext: Pre-prod deployment successful
+        - pretext: PreProd deployment successful
           color: good
           title: Concourse Build $BUILD_ID
           title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
@@ -972,7 +1080,7 @@ jobs:
     params:
       channel: '#eq-author'
       attachments:
-        - pretext: Pre-prod deployment successful
+        - pretext: PreProd deployment successful
           color: good
           title: Concourse Build $BUILD_ID
           title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID


### PR DESCRIPTION
The is the same logic that is used on the staging deployment to test that the correct versions of Runner and Author are deployed before making the build a success