### PR TITLE
Update terraform config to pass schema validator url to Publisher.

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -945,6 +945,7 @@ jobs:
       TF_VAR_firebase_project_id: ((preprod_author_firebase_project_id))
       TF_VAR_firebase_api_key: ((preprod_author_firebase_api_key))
       TF_VAR_firebase_messaging_sender_id: ((preprod_author_firebase_messaging_sender_id))
+      TF_VAR_schema_validator_url: https://preprod-schema-validator.eq.ons.digital
     config:
       platform: linux
       image_resource:


### PR DESCRIPTION
### Description
This PR updates the eQ terraform configuration to pass the URL of the schema validator service down to the `eq-author-deploy` terraform module. See [related PR](https://github.com/ONSdigital/eq-author-deploy/pull/8).

### How to review
Review the Terraform config to ensure it is correct.

### Dependencies
This PR depends on a change to Publisher. https://github.com/ONSdigital/eq-publisher/pull/45