### PR TITLE
Add additional variables into the staging deploy task.

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -462,6 +462,10 @@ jobs:
       TF_VAR_auto_deploy_updated_tags: false
       TF_VAR_ecs_cluster_min_size: 3
       TF_VAR_survey_runner_min_tasks: 3
+      TF_VAR_author_enable_auth: true
+      TF_VAR_author_firebase_project_id: {{staging_author_firebase_project_id}}
+      TF_VAR_author_firebase_api_key: {{staging_author_firebase_api_key}}
+      TF_VAR_author_firebase_messaging_sender_id: {{staging_author_firebase_messaging_sender_id}}
     config:
       platform: linux
       image_resource:

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -3,6 +3,9 @@ dev_aws_access_key:
 dev_aws_secret_key:
 staging_ons_access_ips:
 staging_certificate_arn:
+staging_author_firebase_project_id:
+staging_author_firebase_api_key:
+staging_author_firebase_messaging_sender_id:
 
 # PreProd
 preprod_aws_access_key:


### PR DESCRIPTION
### Description
The eq-smoke-tests now require staging to receive some different environment variables during it's deployment.

This PR adds additional configuration variables into the concourse pipeline definition.