### PR TITLE
Remove AWS keys

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -47,15 +47,11 @@ resources:
   type: docker-image
   source:
     repository: ((docker_registry))/eq-survey-runner
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: survey-runner-static-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-survey-runner-static
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: slack-alert
   type: slack-notification
@@ -123,32 +119,30 @@ jobs:
       include_source_tarball: true
     trigger: true
   - get: eq-terraform-release
-    version: { tag: '17.0.2' }
+    version: { tag: '19.0.0' }
     trigger: true
     params:
       include_source_tarball: true
   - get: eq-terraform-dynamodb-release
-    version: { tag: 'v1.3' }
+    version: { tag: 'v2.0' }
     trigger: true
     params:
       include_source_tarball: true
   - get: eq-terraform-ecs-release
-    version: { tag: 'v3.3' }
+    version: { tag: 'v4.0' }
     trigger: true
     params:
       include_source_tarball: true
   - get: eq-ecs-deploy-release
-    version: { tag: 'v1.5.1' }
+    version: { tag: 'v2.0' }
     trigger: true
     params:
       include_source_tarball: true
   - task: Deploy EQ VPC
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_cidr_block: '10.30.21.0/24'
       TF_VAR_database_cidrs: ["10.30.21.96/28", "10.30.21.112/28", "10.30.21.128/28"]
     config:
@@ -172,15 +166,13 @@ jobs:
           cd eq-terraform/survey-runner-vpc
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-vpc"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-vpc" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Routing
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_internet_gateway_id: '((preprod_internet_gateway_id))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_vpc_peer_connection_id: '((preprod_vpc_peer_connection_id))'
@@ -209,15 +201,13 @@ jobs:
           cd eq-terraform/survey-runner-routing
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-routing"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-routing" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ ECS
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_application_cidrs: ["10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
       TF_VAR_vpc_peer_cidr_block: ["10.30.26.0/24"]
@@ -247,15 +237,13 @@ jobs:
           cd eq-terraform-ecs
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=eq-terraform-ecs"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Alerting
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_slack_webhook_path: '((slack_webhook_path))'
       TF_VAR_slack_channel: 'ops-preprod'
     config:
@@ -279,15 +267,13 @@ jobs:
           cd eq-terraform/survey-runner-alerting
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-alerting"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-alerting" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Survey Runner Database
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_application_cidrs: ["10.30.21.48/28","10.30.21.64/28","10.30.21.80/28","10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
       TF_VAR_database_name: '((preprod_database_name))'
@@ -323,15 +309,13 @@ jobs:
           cd eq-terraform/survey-runner-database
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-database"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-database" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Author Database
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_application_cidrs: ["10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
       TF_VAR_database_name: '((preprod_author_database_name))'
@@ -367,15 +351,13 @@ jobs:
           cd eq-terraform/survey-runner-database
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=author-database"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=author-database" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Survey Runner DynamoDB
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
     config:
       platform: linux
@@ -398,15 +380,13 @@ jobs:
           cd eq-terraform-dynamodb
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=eq-survey-runner-dynamodb"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=eq-survey-runner-dynamodb" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Survey Runner Queue
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_internet_gateway_id: '((preprod_internet_gateway_id))'
       TF_VAR_queue_cidrs: ["10.30.21.0/27"]
@@ -446,16 +426,14 @@ jobs:
           cd eq-terraform/survey-runner-queue
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-queue"
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-queue" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
 #          terraform plan
 
   - task: Deploy EQ Survey Runner
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod-new'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -492,18 +470,16 @@ jobs:
 
           release_version=$(cat ../../eq-survey-runner-release/tag)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-runner""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-runner"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$release_version \
           -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((preprod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((preprod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((preprod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((preprod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((preprod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((preprod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"preprod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"preprod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"preprod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"preprod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_NEW_RELIC_ENABLED\",\"value\": \"False\"},{\"name\": \"NEW_RELIC_APP_NAME\",\"value\": \"PreProd - Survey Runner - ECS\"},{\"name\": \"NEW_RELIC_LICENSE_KEY\",\"value\": \"((new_relic_licence_key))\"}"' \
           -var 'task_iam_policy_json="{\"Version\": \"2012-10-17\",\"Statement\": [{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\": \"arn:aws:s3:::*\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\"],\"Resource\": \"((preprod_submitted_responses_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((preprod_questionnaire_state_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((preprod_eq_session_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\"],\"Resource\": \"((preprod_used_jti_claim_table_arn))\"}]}"'
   - task: Deploy EQ Survey Runner Static
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod-new'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -540,7 +516,7 @@ jobs:
 
           release_version=$(cat ../../eq-survey-runner-release/tag)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-runner-static""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-runner-static"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$release_version
 
@@ -612,11 +588,9 @@ jobs:
       include_source_tarball: true
   - task: Deploy EQ VPC
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_cidr_block: '10.30.20.0/24'
       TF_VAR_database_cidrs: ["10.30.20.96/28", "10.30.20.112/28", "10.30.20.128/28"]
     config:
@@ -640,15 +614,13 @@ jobs:
           cd eq-terraform/survey-runner-vpc
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-vpc"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-vpc" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan
   - task: Deploy EQ Routing
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_vpc_peer_connection_id: '((prod_vpc_peer_connection_id))'
@@ -677,15 +649,13 @@ jobs:
           cd eq-terraform/survey-runner-routing
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-routing"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-routing" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan
   - task: Deploy EQ ECS
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_application_cidrs: ["10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
       TF_VAR_vpc_peer_cidr_block: ["10.30.27.0/24"]
@@ -715,15 +685,13 @@ jobs:
           cd eq-terraform-ecs
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan
   - task: Deploy EQ Alerting
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_slack_webhook_path: '((slack_webhook_path))'
       TF_VAR_slack_channel: 'ops'
     config:
@@ -747,15 +715,13 @@ jobs:
           cd eq-terraform/survey-runner-alerting
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-alerting"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-alerting" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan
   - task: Deploy EQ Survey Runner Database
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_application_cidrs: ["10.30.20.48/28","10.30.20.64/28","10.30.20.80/28","10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
       TF_VAR_database_name: '((prod_database_name))'
@@ -791,15 +757,13 @@ jobs:
           cd eq-terraform/survey-runner-database
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-database"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-database" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan
   - task: Deploy EQ Survey Runner DynamoDB
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
     config:
       platform: linux
@@ -822,15 +786,13 @@ jobs:
           cd eq-terraform-dynamodb
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-dynamodb"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-dynamodb" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan
   - task: Deploy EQ Survey Runner Queue
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
       TF_VAR_queue_cidrs: ["10.30.20.0/27"]
@@ -870,16 +832,14 @@ jobs:
           cd eq-terraform/survey-runner-queue
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-queue"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-queue" -backend-config="role_arn="((prod_aws_assume_role_arn))""
 #          terraform plan
 
   - task: Deploy EQ Survey Runner
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -919,18 +879,16 @@ jobs:
 
           release_version=$(cat ../../eq-survey-runner-release/tag)
 
-          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="ecs-survey-runner""
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="ecs-survey-runner"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan \
           -var container_tag=$release_version \
           -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((prod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((prod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((prod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((prod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((prod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((prod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"prod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"prod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"prod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"prod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"prod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"False\"},{\"name\": \"EQ_NEW_RELIC_ENABLED\",\"value\": \"True\"},{\"name\": \"NEW_RELIC_APP_NAME\",\"value\": \"Prod - Survey Runner - ECS\"},{\"name\": \"NEW_RELIC_LICENSE_KEY\",\"value\": \"((new_relic_licence_key))\"}"' \
           -var 'task_iam_policy_json="{\"Version\": \"2012-10-17\",\"Statement\": [{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\": \"arn:aws:s3:::*\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\"],\"Resource\": \"((prod_submitted_responses_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_questionnaire_state_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_eq_session_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\"],\"Resource\": \"((prod_used_jti_claim_table_arn))\"}]}"'
   - task: Deploy EQ Survey Runner Static
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -969,7 +927,7 @@ jobs:
 
           release_version=$(cat ../../eq-survey-runner-release/tag)
 
-          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="preprod-ecs-survey-runner-static""
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="preprod-ecs-survey-runner-static"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform plan \
           -var container_tag=$release_version
 
@@ -1017,11 +975,9 @@ jobs:
       include_source_tarball: true
   - task: Deploy EQ VPC
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_cidr_block: '10.30.20.0/24'
       TF_VAR_database_cidrs: ["10.30.20.96/28", "10.30.20.112/28", "10.30.20.128/28"]
     config:
@@ -1045,15 +1001,13 @@ jobs:
           cd eq-terraform/survey-runner-vpc
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-vpc"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-vpc" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Routing
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_vpc_peer_connection_id: '((prod_vpc_peer_connection_id))'
@@ -1082,15 +1036,13 @@ jobs:
           cd eq-terraform/survey-runner-routing
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-routing"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-routing" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ ECS
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_application_cidrs: ["10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
       TF_VAR_vpc_peer_cidr_block: ["10.30.27.0/24"]
@@ -1120,15 +1072,13 @@ jobs:
           cd eq-terraform-ecs
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Alerting
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_slack_webhook_path: '((slack_webhook_path))'
       TF_VAR_slack_channel: 'ops'
     config:
@@ -1152,15 +1102,13 @@ jobs:
           cd eq-terraform/survey-runner-alerting
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-alerting"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-alerting" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Survey Runner Database
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_application_cidrs: ["10.30.20.48/28","10.30.20.64/28","10.30.20.80/28","10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
       TF_VAR_database_name: '((prod_database_name))'
@@ -1196,15 +1144,13 @@ jobs:
           cd eq-terraform/survey-runner-database
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-database"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-database" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Survey Runner DynamoDB
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
     config:
       platform: linux
@@ -1227,15 +1173,13 @@ jobs:
           cd eq-terraform-dynamodb
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-dynamodb"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-dynamodb" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply
   - task: Deploy EQ Survey Runner Queue
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
       TF_VAR_queue_cidrs: ["10.30.20.0/27"]
@@ -1275,16 +1219,14 @@ jobs:
           cd eq-terraform/survey-runner-queue
           tfenv install
 
-          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-queue"
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-queue" -backend-config="role_arn="((prod_aws_assume_role_arn))""
 #          terraform plan
 
   - task: Deploy EQ Survey Runner
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -1324,18 +1266,16 @@ jobs:
 
           release_version=$(cat ../../eq-survey-runner-release/tag)
 
-          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="ecs-survey-runner""
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="ecs-survey-runner"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$release_version \
-          -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((prod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((prod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((prod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((prod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((prod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((prod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"prod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"prod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"prod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"prod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"prod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"False\"},{\"name\": \"EQ_NEW_RELIC_ENABLED\",\"value\": \"False\"},{\"name\": \"NEW_RELIC_APP_NAME\",\"value\": \"Prod - Survey Runner - ECS\"},{\"name\": \"NEW_RELIC_LICENSE_KEY\",\"value\": \"((new_relic_licence_key))\"}"' \
+          -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((prod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((prod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((prod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((prod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((prod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((prod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"prod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"prod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"prod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"prod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"prod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"False\"}"' \
           -var 'task_iam_policy_json="{\"Version\": \"2012-10-17\",\"Statement\": [{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\": \"arn:aws:s3:::*\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\"],\"Resource\": \"((prod_submitted_responses_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_questionnaire_state_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_eq_session_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\"],\"Resource\": \"((prod_used_jti_claim_table_arn))\"}]}"'
   - task: Deploy EQ Survey Runner Static
     params:
-      AWS_ACCESS_KEY_ID: ((prod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((prod_aws_secret_key))
       TF_VAR_env: 'prod'
-      TF_VAR_aws_access_key: '((prod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((prod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -1374,7 +1314,7 @@ jobs:
 
           release_version=$(cat ../../eq-survey-runner-release/tag)
 
-          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="preprod-ecs-survey-runner-static""
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="preprod-ecs-survey-runner-static"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$release_version
 

--- a/eq.yml
+++ b/eq.yml
@@ -820,6 +820,7 @@ jobs:
       TF_VAR_container_name: 'go-launch-a-survey'
       TF_VAR_container_port: 8000
       TF_VAR_listener_rule_priority: 101
+      TF_VAR_healthcheck_path: '/status'
       TF_VAR_task_has_iam_policy: true
       TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
     config:

--- a/eq.yml
+++ b/eq.yml
@@ -78,68 +78,61 @@ resources:
     uri: https://github.com/ONSdigital/eq-address-lookup-api.git
     branch: master
 
+- name: eq-lookup-api
+  type: git
+  source:
+    uri: https://github.com/ONSdigital/eq-lookup-api.git
+    branch: master
+
 - name: survey-runner-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-survey-runner
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: survey-runner-static-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-survey-runner-static
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: eq-author-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-author
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: eq-author-api-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-author-api
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: eq-publisher-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-publisher
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: go-launch-a-survey-image
   type: docker-image
   source:
     repository: ((docker_registry))/go-launch-a-survey
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: eq-survey-register-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-survey-register
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: eq-schema-validator-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-schema-validator
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
 
 - name: eq-address-lookup-api-image
   type: docker-image
   source:
     repository: ((docker_registry))/eq-address-lookup-api
-    aws_access_key_id: ((dev_aws_access_key))
-    aws_secret_access_key: ((dev_aws_secret_key))
+
+- name: eq-lookup-api-image
+  type: docker-image
+  source:
+    repository: ((docker_registry))/eq-lookup-api
 
 - name: slack-alert
   type: slack-notification
@@ -443,6 +436,18 @@ jobs:
     get_params:
       skip_download: true
 
+- name: build-eq-lookup-api
+  public: true
+  plan:
+  - get: eq-lookup-api
+    trigger: true
+  - put: eq-lookup-api-image
+    params:
+      build: eq-lookup-api
+      tag: eq-lookup-api/.git/HEAD
+    get_params:
+      skip_download: true
+
 - name: staging-deploy
   public: true
   serial_groups: [staging-deploy, staging-smoke-tests, staging-destroy]
@@ -473,6 +478,9 @@ jobs:
   - get: eq-address-lookup-api
     passed: [build-eq-address-lookup-api]
     trigger: true
+  - get: eq-lookup-api
+    passed: [build-eq-lookup-api]
+    trigger: true
   - get: eq-terraform
     trigger: true
   - get: eq-terraform-ecs
@@ -481,12 +489,10 @@ jobs:
     trigger: true
   - task: Deploy Terraform
     params:
-      AWS_ACCESS_KEY_ID: ((dev_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((dev_aws_secret_key))
       ANSIBLE_HOST_KEY_CHECKING: False
       TF_VAR_env: 'staging'
-      TF_VAR_aws_access_key: '((dev_aws_access_key))'
-      TF_VAR_aws_secret_key: '((dev_aws_secret_key))'
+      TF_VAR_aws_account_id: '((dev_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((dev_aws_assume_role_arn))'
       TF_VAR_aws_key_pair: staging
       TF_VAR_ons_access_ips: {{staging_ons_access_ips}}
       TF_VAR_certificate_arn: {{staging_certificate_arn}}
@@ -516,6 +522,7 @@ jobs:
       - name: eq-publisher
       - name: go-launch-a-survey
       - name: eq-schema-validator
+      - name: eq-lookup-api
       run:
         path: bash
         args:
@@ -535,8 +542,9 @@ jobs:
           eq_publisher_tag=$(cat ../eq-publisher/.git/HEAD | xargs echo -n)
           go_launch_a_survey_tag=$(cat ../go-launch-a-survey/.git/HEAD | xargs echo -n)
           eq_schema_validator_tag=$(cat ../eq-schema-validator/.git/HEAD | xargs echo -n)
+          eq_lookup_api_tag=$(cat ../eq-lookup-api/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="key="staging""
+          terraform init -backend-config="key="staging"" -backend-config="role_arn="((dev_aws_assume_role_arn))""
           echo "eu-west-1" | terraform apply \
             -var survey_runner_tag=$survey_runner_tag \
             -var survey_launcher_tag=$go_launch_a_survey_tag \
@@ -544,7 +552,8 @@ jobs:
             -var author_api_tag=$eq_author_api_tag \
             -var publisher_tag=$eq_publisher_tag \
             -var survey_launcher_tag=$go_launch_a_survey_tag \
-            -var schema_validator_tag=$eq_schema_validator_tag
+            -var schema_validator_tag=$eq_schema_validator_tag \
+            -var suggest_api_tag=$eq_lookup_api_tag
     on_failure:
       put: slack-alert
       params:
@@ -733,11 +742,9 @@ jobs:
     passed: [staging-deploy]
   - task: Destroy Terraform
     params:
-      AWS_ACCESS_KEY_ID: ((dev_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((dev_aws_secret_key))
       TF_VAR_env: 'staging'
-      TF_VAR_aws_access_key: '((dev_aws_access_key))'
-      TF_VAR_aws_secret_key: '((dev_aws_secret_key))'
+      TF_VAR_aws_account_id: '((dev_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((dev_aws_assume_role_arn))'
       TF_VAR_aws_key_pair: staging
       TF_VAR_ons_access_ips: {{staging_ons_access_ips}}
       TF_VAR_certificate_arn: {{staging_certificate_arn}}
@@ -768,7 +775,7 @@ jobs:
 
           echo -e "" > staging.pem
 
-          terraform init -backend-config="key="staging""
+          terraform init -backend-config="key="staging"" -backend-config="role_arn="((dev_aws_assume_role_arn))""
           echo "eu-west-1" | terraform destroy -force
 
 
@@ -801,11 +808,9 @@ jobs:
   - get: eq-ecs-deploy
   - task: Deploy Survey Launcher
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod-new'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -836,7 +841,7 @@ jobs:
 
           survey_launcher_tag=$(cat ../go-launch-a-survey/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-launcher""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-launcher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$survey_launcher_tag \
           -var 'container_environment_variables="{\"name\": \"JWT_ENCRYPTION_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-encryption-sr-public-key.pem\"},{\"name\": \"JWT_SIGNING_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-signing-rrm-private-key.pem\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets\"},{\"name\": \"SURVEY_RUNNER_URL\",\"value\": \"https://preprod-new-surveys.eq.ons.digital\"}"' \
@@ -845,11 +850,9 @@ jobs:
 
   - task: Deploy Schema Validator
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -880,16 +883,14 @@ jobs:
 
           schema_validator_tag=$(cat ../eq-schema-validator/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-schema-validator""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-schema-validator"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$schema_validator_tag
   - task: Deploy Survey Register
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -919,16 +920,14 @@ jobs:
 
           survey_register_tag=$(cat ../eq-survey-register/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-survey-register""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-survey-register"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$survey_register_tag
   - task: Deploy Author
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -961,18 +960,16 @@ jobs:
 
           author_tag=$(cat ../eq-author/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-author""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-author"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$author_tag \
           -var 'container_environment_variables="{\"name\": \"REACT_APP_BASE_NAME\", \"value\": \"/eq-author\" },{ \"name\": \"REACT_APP_USE_MOCK_API\", \"value\": \"false\" },{ \"name\": \"REACT_APP_API_URL\", \"value\": \"https://preprod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"REACT_APP_PUBLISHER_URL\", \"value\": \"https://preprod-publisher.eq.ons.digital/publish\" },{ \"name\": \"REACT_APP_GO_LAUNCH_A_SURVEY_URL\", \"value\": \"https://preprod-new-surveys-launch.eq.ons.digital/quick-launch\" },{ \"name\": \"REACT_APP_USE_FULLSTORY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_USE_SENTRY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_ENABLE_AUTH\", \"value\": \"true\" },{ \"name\": \"REACT_APP_FIREBASE_PROJECT_ID\", \"value\": \"((preprod_author_firebase_project_id))\" },{ \"name\": \"REACT_APP_FIREBASE_API_KEY\", \"value\": \"((preprod_author_firebase_api_key))\" },{ \"name\": \"REACT_APP_FIREBASE_MESSAGING_SENDER_ID\", \"value\": \"((preprod_author_firebase_messaging_sender_id))\" }"'
           
   - task: Deploy Author-Api
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -1003,17 +1000,15 @@ jobs:
 
           author_api_tag=$(cat ../eq-author-api/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-author-api""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-author-api"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$author_api_tag \
           -var 'container_environment_variables="{\"name\": \"DB_CONNECTION_URI\", \"value\": \"((preprod_author_database_connection_string))\"}"'
   - task: Deploy Publisher
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -1044,18 +1039,16 @@ jobs:
 
           publisher_tag=$(cat ../eq-publisher/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-publisher""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-publisher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$publisher_tag \
           -var 'container_environment_variables="{ \"name\": \"EQ_AUTHOR_API_URL\", \"value\": \"https://preprod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"EQ_SCHEMA_VALIDATOR_URL\", \"value\": \"https://preprod-schema-validator.eq.ons.digital/validate\" }"'
 
   - task: Deploy Address Lookup API
     params:
-      AWS_ACCESS_KEY_ID: ((preprod_aws_access_key))
-      AWS_SECRET_ACCESS_KEY: ((preprod_aws_secret_key))
       TF_VAR_env: 'preprod'
-      TF_VAR_aws_access_key: '((preprod_aws_access_key))'
-      TF_VAR_aws_secret_key: '((preprod_aws_secret_key))'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'preprod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
@@ -1086,7 +1079,7 @@ jobs:
 
           address_lookup_api_tag=$(cat ../eq-address-lookup-api/.git/HEAD | xargs echo -n)
 
-          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-address-lookup-api""
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-address-lookup-api"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$address_lookup_api_tag \
           -var 'container_environment_variables="{ \"name\": \"LOOKUP_URL\", \"value\": \"((preprod_address_lookup_url))\" },{ \"name\": \"AUTH_KEY\", \"value\": \"((preprod_address_lookup_auth_token))\" }"'

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -1,6 +1,6 @@
 # Dev
-dev_aws_access_key:
-dev_aws_secret_key:
+dev_aws_account_id:
+dev_aws_assume_role_arn:
 staging_ons_access_ips:
 staging_certificate_arn:
 staging_author_firebase_project_id:
@@ -8,8 +8,8 @@ staging_author_firebase_api_key:
 staging_author_firebase_messaging_sender_id:
 
 # PreProd
-preprod_aws_access_key:
-preprod_aws_secret_key:
+preprod_aws_account_id:
+preprod_aws_assume_role_arn:
 preprod_ons_access_ips:
 preprod_vpc_id:
 preprod_aws_alb_arn:
@@ -58,8 +58,8 @@ preprod_address_lookup_url:
 preprod_address_lookup_auth_token:
 
 # Prod
-prod_aws_access_key:
-prod_aws_secret_key:
+prod_aws_account_id:
+prod_aws_assume_role_arn:
 prod_ons_access_ips:
 prod_vpc_id:
 prod_aws_alb_arn:


### PR DESCRIPTION
Removed all AWS keys from pipelines.
Concourse no longer uses keys to deploy to AWS environments. Now all environments are deployed using an assumed role.
This is 👍 for security as there are no keys to rotate / loose