### PR TITLE
Add release-triggered deployment of Author to pre-prod and prod.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -848,6 +848,793 @@ jobs:
           title: Concourse Build $BUILD_ID
           title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
 
+- name: Author-PreProd-Deploy
+  public: true
+  max_in_flight: 1
+  plan:
+  - get: eq-survey-runner-release
+    passed: [build-eq-survey-runner]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-author-release
+    passed: [build-eq-author]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-author-api-release
+    passed: [build-eq-author-api]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-publisher-release
+    passed: [build-eq-publisher]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-schema-validator-release
+    passed: [build-eq-schema-validator]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: go-launch-a-survey-release
+    passed: [build-go-launch-a-survey]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-terraform-release
+    version: { tag: '19.0.0' }
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-dynamodb-release
+    version: { tag: 'v2.0' }
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-ecs-release
+    version: { tag: 'v4.0' }
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: eq-ecs-deploy-release
+    version: { tag: 'v2.0' }
+    trigger: true
+    params:
+      include_source_tarball: true
+  - task: Deploy EQ VPC
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_cidr_block: '10.30.21.0/24'
+      TF_VAR_database_cidrs: ["10.30.21.96/28", "10.30.21.112/28", "10.30.21.128/28"]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-vpc
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-vpc" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+
+  - task: Deploy EQ Routing
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_internet_gateway_id: '((preprod_internet_gateway_id))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_vpc_peer_connection_id: '((preprod_vpc_peer_connection_id))'
+      TF_VAR_vpc_peer_cidr_block: '10.30.26.0/24'
+      TF_VAR_public_cidrs: ["10.30.21.144/28","10.30.21.160/28","10.30.21.176/28"]
+      TF_VAR_database_subnet_ids: ((preprod_database_subnet_ids))
+      TF_VAR_database_cidrs: ["10.30.21.96/28", "10.30.21.112/28", "10.30.21.128/28"]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-routing
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-routing" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+
+  - task: Deploy EQ ECS
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_application_cidrs: ["10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
+      TF_VAR_vpc_peer_cidr_block: ["10.30.26.0/24"]
+      TF_VAR_certificate_arn: '((preprod_certificate_arn))'
+      TF_VAR_public_subnet_ids: '((preprod_public_subnet_ids))'
+      TF_VAR_private_route_table_ids: '((preprod_private_route_table_ids))'
+      TF_VAR_ons_access_ips: '((preprod_ons_access_ips))'
+      TF_VAR_eq_gateway_ips: '((preprod_eq_gateway_ips))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-ecs-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-ecs-release
+
+          mkdir eq-terraform-ecs
+          tar -xzf source.tar.gz -C eq-terraform-ecs --strip-components=1
+
+          cd eq-terraform-ecs
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+
+  - task: Deploy EQ Alerting
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_slack_webhook_path: '((slack_webhook_path))'
+      TF_VAR_slack_channel: 'ops-preprod'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-alerting
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-alerting" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+  - task: Deploy EQ Survey Runner Database
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_application_cidrs: ["10.30.21.48/28","10.30.21.64/28","10.30.21.80/28","10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
+      TF_VAR_database_name: '((preprod_database_name))'
+      TF_VAR_database_user: '((preprod_database_user))'
+      TF_VAR_database_password: '((preprod_database_password))'
+      TF_VAR_database_instance_class: 'db.r3.xlarge'
+      TF_VAR_database_engine_version: '9.4.15'
+      TF_VAR_database_apply_immediately: true
+      TF_VAR_database_allocated_storage: 640
+      TF_VAR_snapshot_identifier: '((preprod_database_snapshot_identifier))'
+      TF_VAR_preferred_maintenance_window: 'tue:02:00-tue:02:30'
+      TF_VAR_db_subnet_group_name: 'preprod-eq-rds'
+      TF_VAR_database_identifier: 'preprod-digitaleqrds'
+      TF_VAR_rds_security_group_name: 'preprod-rds-access'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-database
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-database" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+
+  - task: Deploy EQ Author Database
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_application_cidrs: ["10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
+      TF_VAR_database_name: '((preprod_author_database_name))'
+      TF_VAR_database_user: '((preprod_author_database_user))'
+      TF_VAR_database_password: '((preprod_author_database_password))'
+      TF_VAR_database_instance_class: 'db.t2.small'
+      TF_VAR_database_engine_version: '9.4.15'
+      TF_VAR_database_apply_immediately: true
+      TF_VAR_database_allocated_storage: 100
+      TF_VAR_snapshot_identifier: '((preprod_author_database_snapshot_identifier))'
+      TF_VAR_preferred_maintenance_window: 'tue:02:00-tue:02:30'
+      TF_VAR_db_subnet_group_name: 'preprod-eq-rds'
+      TF_VAR_database_identifier: 'preprod-eq-author'
+      TF_VAR_rds_security_group_name: 'preprod-author-rds-access'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-database
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=author-database" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+
+  - task: Deploy EQ Survey Runner DynamoDB
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-dynamodb-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-dynamodb-release
+
+          mkdir eq-terraform-dynamodb
+          tar -xzf source.tar.gz -C eq-terraform-dynamodb --strip-components=1
+
+          cd eq-terraform-dynamodb
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=eq-survey-runner-dynamodb" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply
+          terraform plan
+  - task: Deploy EQ Survey Runner Queue
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_internet_gateway_id: '((preprod_internet_gateway_id))'
+      TF_VAR_queue_cidrs: ["10.30.21.0/27"]
+      TF_VAR_rabbitmq_ips: ["((preprod_rabbitmq_ip_prime))","((preprod_rabbitmq_ip_failover))"]
+      TF_VAR_application_cidrs: ["10.30.21.48/28","10.30.21.64/28","10.30.21.80/28","10.30.21.192/28","10.30.21.208/28","10.30.21.224/28"]
+      TF_VAR_rsyslogd_server_ip: "10.172.92.242"
+      TF_VAR_logserver_cidr: "10.171.93.21/32"
+      TF_VAR_audit_cidr: "10.172.92.242/32"
+      TF_VAR_sdx_cidrs: ["10.29.1.11/32","10.50.29.20/32","10.50.29.21/32",]
+
+      TF_VAR_aws_key_pair: '((preprod_queue_key_pair))'
+      TF_VAR_rabbitmq_instance_type: 't2.small'
+      TF_VAR_rabbitmq_admin_user: '((preprod_rabbitmq_admin_user))'
+      TF_VAR_rabbitmq_admin_password: '((preprod_rabbitmq_admin_password))'
+      TF_VAR_rabbitmq_write_user: '((preprod_rabbitmq_write_user))'
+      TF_VAR_rabbitmq_write_password: '((preprod_rabbitmq_write_password))'
+      TF_VAR_rabbitmq_read_user: '((preprod_rabbitmq_read_user))'
+      TF_VAR_rabbitmq_read_password: '((preprod_rabbitmq_read_password))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-queue
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-terraform-state" -backend-config "key=survey-runner-queue" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+        #          terraform plan
+
+  - task: Deploy EQ Survey Runner
+    params:
+      TF_VAR_env: 'preprod-new'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'surveys'
+      TF_VAR_container_name: 'eq-survey-runner'
+      TF_VAR_container_port: 5000
+      TF_VAR_listener_rule_priority: 10
+      TF_VAR_task_has_iam_policy: true
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+      TF_VAR_healthcheck_path: '/status'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+
+          mkdir eq-ecs-deploy
+          tar -xzf source.tar.gz -C eq-ecs-deploy --strip-components=1
+
+          cd eq-ecs-deploy
+          tfenv install
+
+          release_version=$(cat ../../eq-survey-runner-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-runner"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$release_version \
+          -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((preprod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((preprod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((preprod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((preprod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((preprod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((preprod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"preprod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"preprod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"preprod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"preprod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_NEW_RELIC_ENABLED\",\"value\": \"False\"},{\"name\": \"NEW_RELIC_APP_NAME\",\"value\": \"PreProd - Survey Runner - ECS\"},{\"name\": \"NEW_RELIC_LICENSE_KEY\",\"value\": \"((new_relic_licence_key))\"}"' \
+          -var 'task_iam_policy_json="{\"Version\": \"2012-10-17\",\"Statement\": [{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\": \"arn:aws:s3:::*\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\"],\"Resource\": \"((preprod_submitted_responses_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((preprod_questionnaire_state_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((preprod_eq_session_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\"],\"Resource\": \"((preprod_used_jti_claim_table_arn))\"}]}"'
+
+  - task: Deploy EQ Survey Runner Static
+    params:
+      TF_VAR_env: 'preprod-new'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_dns_record_name: 'preprod-new-surveys.eq.ons.digital'
+      TF_VAR_service_name: 'surveys-static'
+      TF_VAR_container_name: 'eq-survey-runner-static'
+      TF_VAR_container_port: 80
+      TF_VAR_listener_rule_priority: 5
+      TF_VAR_alb_listener_path_pattern: '/s/*'
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+
+          mkdir eq-ecs-deploy
+          tar -xzf source.tar.gz -C eq-ecs-deploy --strip-components=1
+
+          cd eq-ecs-deploy
+          tfenv install
+
+          release_version=$(cat ../../eq-survey-runner-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-runner-static"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$release_version
+
+  - task: Deploy Survey Launcher
+    params:
+      TF_VAR_env: 'preprod-new'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'surveys-launch'
+      TF_VAR_container_name: 'go-launch-a-survey'
+      TF_VAR_container_port: 8000
+      TF_VAR_listener_rule_priority: 101
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_task_has_iam_policy: true
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: go-launch-a-survey-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          survey_launcher_tag=$(cat ../go-launch-a-survey-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-launcher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$survey_launcher_tag \
+          -var 'container_environment_variables="{\"name\": \"JWT_ENCRYPTION_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-encryption-sr-public-key.pem\"},{\"name\": \"JWT_SIGNING_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-signing-rrm-private-key.pem\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets\"},{\"name\": \"SURVEY_RUNNER_URL\",\"value\": \"https://preprod-new-surveys.eq.ons.digital\"}"' \
+          -var 'task_iam_policy_json="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Action\":[\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::preprod-secrets*\"}]}"'
+
+  - task: Deploy Schema Validator
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'schema-validator'
+      TF_VAR_container_name: 'eq-schema-validator'
+      TF_VAR_container_port: 5000
+      TF_VAR_listener_rule_priority: 500
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-schema-validator-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          schema_validator_tag=$(cat ../eq-schema-validator-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-schema-validator"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$schema_validator_tag
+
+  - task: Deploy Author
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'author'
+      TF_VAR_container_name: 'eq-author'
+      TF_VAR_container_port: 3000
+      TF_VAR_listener_rule_priority: 102
+      TF_VAR_healthcheck_path: '/status.json'
+      TF_VAR_healthcheck_grace_period_seconds: 60
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+      TF_VAR_high_cpu_threshold: 80
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          author_tag=$(cat ../eq-author-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-author"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$author_tag \
+          -var 'container_environment_variables="{\"name\": \"REACT_APP_BASE_NAME\", \"value\": \"/eq-author\" },{ \"name\": \"REACT_APP_USE_MOCK_API\", \"value\": \"false\" },{ \"name\": \"REACT_APP_API_URL\", \"value\": \"https://preprod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"REACT_APP_PUBLISHER_URL\", \"value\": \"https://preprod-publisher.eq.ons.digital/publish\" },{ \"name\": \"REACT_APP_GO_LAUNCH_A_SURVEY_URL\", \"value\": \"https://preprod-new-surveys-launch.eq.ons.digital/quick-launch\" },{ \"name\": \"REACT_APP_USE_FULLSTORY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_USE_SENTRY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_ENABLE_AUTH\", \"value\": \"true\" },{ \"name\": \"REACT_APP_FIREBASE_PROJECT_ID\", \"value\": \"((preprod_author_firebase_project_id))\" },{ \"name\": \"REACT_APP_FIREBASE_API_KEY\", \"value\": \"((preprod_author_firebase_api_key))\" },{ \"name\": \"REACT_APP_FIREBASE_MESSAGING_SENDER_ID\", \"value\": \"((preprod_author_firebase_messaging_sender_id))\" }"'
+
+  - task: Deploy Author-Api
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'author-api'
+      TF_VAR_container_name: 'eq-author-api'
+      TF_VAR_container_port: 4000
+      TF_VAR_listener_rule_priority: 103
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-api-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          author_api_tag=$(cat ../eq-author-api-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-author-api"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$author_api_tag \
+          -var 'container_environment_variables="{\"name\": \"DB_CONNECTION_URI\", \"value\": \"((preprod_author_database_connection_string))\"}"'
+
+  - task: Deploy Publisher
+    params:
+      TF_VAR_env: 'preprod'
+      TF_VAR_aws_account_id: '((preprod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((preprod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'preprod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'publisher'
+      TF_VAR_container_name: 'eq-publisher'
+      TF_VAR_container_port: 9000
+      TF_VAR_listener_rule_priority: 104
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-publisher-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          publisher_tag=$(cat ../eq-publisher-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-publisher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          # terraform apply \
+          terraform plan \
+          -var container_tag=$publisher_tag \
+          -var 'container_environment_variables="{ \"name\": \"EQ_AUTHOR_API_URL\", \"value\": \"https://preprod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"EQ_SCHEMA_VALIDATOR_URL\", \"value\": \"https://preprod-schema-validator.eq.ons.digital/validate\" }"'
+
+  - task: Wait for Deployed EQ Survey Runner
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+
+          survey_runner_tag=$(cat eq-survey-runner-release/tag)
+          while [[ "$(curl -s https://preprod-new-surveys.eq.ons.digital/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
+
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-runner'
+        attachments:
+        - pretext: PreProd Survey Runner Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - put: slack-alert
+    params:
+      channel: '#eq-runner'
+      attachments:
+      - pretext: PreProd deployment successful
+        color: good
+        title: Concourse Build $BUILD_ID
+        title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Wait for Deployed Author API
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-api-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          author_api_tag=$(cat eq-author-api-release/tag)
+          while [[ "$(curl -s https://preprod-author-api.eq.ons.digital/status)" != *"$author_api_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+        - pretext: PreProd Author API Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Wait for Deployed Author
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          author_tag=$(cat eq-author-release/tag)
+          while [[ "$(curl -s https://preprod-author.eq.ons.digital/status.json)" != *"$author_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+        - pretext: PreProd Author Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Wait for Deployed Publisher
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-publisher-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          publisher_tag=$(cat eq-publisher-release/tag)
+          while [[ "$(curl -s https://preprod-publisher.eq.ons.digital/status)" != *"$publisher_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+        - pretext: PreProd Publisher Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - put: slack-alert
+    params:
+      channel: '#eq-author'
+      attachments:
+      - pretext: PreProd deployment successful
+        color: good
+        title: Concourse Build $BUILD_ID
+        title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
 - name: Prod-Deployment-Plan
   max_in_flight: 1
   plan:

--- a/deploy.yml
+++ b/deploy.yml
@@ -58,6 +58,51 @@ resources:
   source:
     url: {{slack_webhook_url}}
 
+- name: eq-author-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: eq-author
+    access_token: ((github_access_token))
+    release: true
+    pre_release: true
+
+- name: eq-author-api-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: eq-author-api
+    access_token: ((github_access_token))
+    release: true
+    pre_release: true
+
+- name: eq-publisher-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: eq-publisher
+    access_token: ((github_access_token))
+    release: true
+    pre_release: true
+
+- name: eq-schema-validator-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: eq-schema-validator
+    access_token: ((github_access_token))
+    release: true
+    pre_release: true
+
+- name: eq-survey-launcher-release
+  type: github-release
+  source:
+    owner: ONSdigital
+    repository: go-launch-a-survey
+    access_token: ((github_access_token))
+    release: true
+    pre_release: true
+
 jobs:
 - name: build-eq-survey-runner
   public: true
@@ -108,6 +153,50 @@ jobs:
       tag: eq-survey-runner-release/tag
     get_params:
       skip_download: true
+
+- name: build-eq-author
+  public: true
+  plan:
+    - get: eq-author-release
+      params:
+        include_source_tarball: true
+      trigger: true
+    - task: Build Image
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source: onsdigital/eq-author-build
+        inputs:
+          - name: eq-author-release
+        outputs:
+          - name: compiled-eq-author
+          - name: build_args
+        run:
+          path: sh
+          args:
+            - -exc
+            - |
+              cd eq-author-release
+
+              mkdir eq-author
+              tar -xzf source.tar.gz -C eq-author --strip-components=1
+
+              cd eq-author
+              yarn install
+
+              cp -R ../eq-author/* ../../compiled-eq-author
+
+              eq_author_tag=$(cat ../tag)
+              echo "{\"APPLICATION_VERSION\":\""$eq_author_tag"\"}" > ../../build_args/args
+              cp ../tag ../../compiled-eq-author/.application-version
+    - put: author-image
+        params:
+          build: compiled-eq-author
+          tag: eq-author-release/tag
+          build_args_file: build_args/args
+        get_params:
+          skip_download: true
 
 - name: PreProd-Deploy
   public: true

--- a/deploy.yml
+++ b/deploy.yml
@@ -311,6 +311,49 @@ jobs:
     get_params:
       skip_download: true
 
+- name: build-eq-schema-validator
+  public: true
+  plan:
+  - get: eq-schema-validator-release
+    params:
+      include_source_tarball: true
+    trigger: true
+  - task: Build Image
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: onsdigital/eq-python-build
+      inputs:
+      - name: eq-schema-validator-release
+      outputs:
+      - name: compiled-eq-schema-validator
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          cd eq-schema-validator-release
+
+          mkdir eq-schema-validator
+          tar -xzf source.tar.gz -C eq-schema-validator --strip-components=1
+
+          pyenv install 3.6.3
+
+          cd eq-schema-validator
+          pip install -U pip pipenv
+          pipenv install --dev --deploy
+          pipenv run ./scripts/build.sh
+
+          cp -R ../eq-schema-validator/* ../../compiled-eq-schema-validator
+          cp ../tag ../../compiled-eq-schema-validator/.application-version
+  - put: schema-validator-image
+    params:
+      build: compiled-eq-schema-validator
+      tag: eq-schema-validator-release/tag
+    get_params:
+      skip_download: true
+
 - name: PreProd-Deploy
   public: true
   max_in_flight: 1

--- a/deploy.yml
+++ b/deploy.yml
@@ -2027,6 +2027,633 @@ jobs:
           title: Concourse Build $BUILD_ID
           title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
 
+- name: Author-Prod-Deployment-Plan
+  max_in_flight: 1
+  plan:
+  - get: eq-survey-runner-release
+    passed: [Author-PreProd-Deploy]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-author-release
+    passed: [Author-PreProd-Deploy]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-author-api-release
+    passed: [Author-PreProd-Deploy]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-publisher-release
+    passed: [Author-PreProd-Deploy]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: go-launch-a-survey-release
+    passed: [Author-PreProd-Deploy]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-schema-validator-release
+    passed: [Author-PreProd-Deploy]
+    params:
+      include_source_tarball: true
+    trigger: true
+  - get: eq-terraform-release
+    passed: [Author-PreProd-Deploy]
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-dynamodb-release
+    passed: [Author-PreProd-Deploy]
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-ecs-release
+    passed: [Author-PreProd-Deploy]
+    trigger: true
+    params:
+      include_source_tarball: true
+  - get: eq-ecs-deploy-release
+    passed: [Author-PreProd-Deploy]
+    trigger: true
+    params:
+      include_source_tarball: true
+  - task: Deploy EQ VPC
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_cidr_block: '10.30.20.0/24'
+      TF_VAR_database_cidrs: ["10.30.20.96/28", "10.30.20.112/28", "10.30.20.128/28"]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-vpc
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-vpc" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan
+
+  - task: Deploy EQ Routing
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_vpc_peer_connection_id: '((prod_vpc_peer_connection_id))'
+      TF_VAR_vpc_peer_cidr_block: '10.30.27.0/24'
+      TF_VAR_public_cidrs: ["10.30.20.144/28","10.30.20.160/28","10.30.20.176/28"]
+      TF_VAR_database_subnet_ids: ((prod_database_subnet_ids))
+      TF_VAR_database_cidrs: ["10.30.20.96/28", "10.30.20.112/28", "10.30.20.128/28"]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-routing
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-routing" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan
+
+  - task: Deploy EQ ECS
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_application_cidrs: ["10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
+      TF_VAR_vpc_peer_cidr_block: ["10.30.27.0/24"]
+      TF_VAR_certificate_arn: '((prod_certificate_arn))'
+      TF_VAR_public_subnet_ids: '((prod_public_subnet_ids))'
+      TF_VAR_private_route_table_ids: '((prod_private_route_table_ids))'
+      TF_VAR_ons_access_ips: '((prod_ons_access_ips))'
+      TF_VAR_eq_gateway_ips: '((prod_eq_gateway_ips))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-ecs-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-ecs-release
+
+          mkdir eq-terraform-ecs
+          tar -xzf source.tar.gz -C eq-terraform-ecs --strip-components=1
+
+          cd eq-terraform-ecs
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan
+
+  - task: Deploy EQ Alerting
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_slack_webhook_path: '((slack_webhook_path))'
+      TF_VAR_slack_channel: 'ops'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-alerting
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-alerting" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan
+
+  - task: Deploy EQ Survey Runner Database
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_application_cidrs: ["10.30.20.48/28","10.30.20.64/28","10.30.20.80/28","10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
+      TF_VAR_database_name: '((prod_database_name))'
+      TF_VAR_database_user: '((prod_database_user))'
+      TF_VAR_database_password: '((prod_database_password))'
+      TF_VAR_database_instance_class: 'db.r3.xlarge'
+      TF_VAR_database_engine_version: '9.4.15'
+      TF_VAR_database_apply_immediately: false
+      TF_VAR_database_allocated_storage: 640
+      TF_VAR_snapshot_identifier: '((prod_database_snapshot_identifier))'
+      TF_VAR_preferred_maintenance_window: 'wed:03:00-wed:03:30'
+      TF_VAR_db_subnet_group_name: 'prod-eq-rds'
+      TF_VAR_database_identifier: 'prod-digitaleqrds'
+      TF_VAR_rds_security_group_name: 'prod-rds-access'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-database
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-database" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan
+
+  - task: Deploy EQ Survey Runner DynamoDB
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-dynamodb-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-dynamodb-release
+
+          mkdir eq-terraform-dynamodb
+          tar -xzf source.tar.gz -C eq-terraform-dynamodb --strip-components=1
+
+          cd eq-terraform-dynamodb
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-dynamodb" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan
+
+  - task: Deploy EQ Survey Runner Queue
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
+      TF_VAR_queue_cidrs: ["10.30.20.0/27"]
+      TF_VAR_rabbitmq_ips: ["((prod_rabbitmq_ip_prime))","((prod_rabbitmq_ip_failover))"]
+      TF_VAR_application_cidrs: ["10.30.20.48/28","10.30.20.64/28","10.30.20.80/28","10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
+      TF_VAR_rsyslogd_server_ip: "10.172.92.242"
+      TF_VAR_logserver_cidr: "10.171.93.21/32"
+      TF_VAR_audit_cidr: "10.172.92.242/32"
+      TF_VAR_sdx_cidrs: ["10.29.1.12/32","10.50.41.20/32","10.50.41.21/32",]
+
+      TF_VAR_aws_key_pair: '((prod_queue_key_pair))'
+      TF_VAR_rabbitmq_instance_type: 't2.medium'
+      TF_VAR_rabbitmq_admin_user: '((prod_rabbitmq_admin_user))'
+      TF_VAR_rabbitmq_admin_password: '((prod_rabbitmq_admin_password))'
+      TF_VAR_rabbitmq_write_user: '((prod_rabbitmq_write_user))'
+      TF_VAR_rabbitmq_write_password: '((prod_rabbitmq_write_password))'
+      TF_VAR_rabbitmq_read_user: '((prod_rabbitmq_read_user))'
+      TF_VAR_rabbitmq_read_password: '((prod_rabbitmq_read_password))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-queue
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-queue" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          # terraform plan
+
+  - task: Deploy EQ Survey Runner
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'surveys'
+      TF_VAR_container_name: 'eq-survey-runner'
+      TF_VAR_container_memory_reservation: 512
+      TF_VAR_application_min_tasks: '3'
+      TF_VAR_container_port: 5000
+      TF_VAR_listener_rule_priority: 10
+      TF_VAR_task_has_iam_policy: true
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_dns_zone_name: '((prod_dns_zone_name))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+
+          mkdir eq-ecs-deploy
+          tar -xzf source.tar.gz -C eq-ecs-deploy --strip-components=1
+
+          cd eq-ecs-deploy
+          tfenv install
+
+          release_version=$(cat ../../eq-survey-runner-release/tag)
+
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="ecs-survey-runner"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$release_version \
+          -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((prod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((prod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((prod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((prod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((prod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((prod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"prod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"prod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"prod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"prod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"prod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"False\"},{\"name\": \"EQ_NEW_RELIC_ENABLED\",\"value\": \"True\"},{\"name\": \"NEW_RELIC_APP_NAME\",\"value\": \"Prod - Survey Runner - ECS\"},{\"name\": \"NEW_RELIC_LICENSE_KEY\",\"value\": \"((new_relic_licence_key))\"}"' \
+          -var 'task_iam_policy_json="{\"Version\": \"2012-10-17\",\"Statement\": [{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\": \"arn:aws:s3:::*\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\"],\"Resource\": \"((prod_submitted_responses_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_questionnaire_state_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_eq_session_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\"],\"Resource\": \"((prod_used_jti_claim_table_arn))\"}]}"'
+
+  - task: Deploy EQ Survey Runner Static
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_dns_record_name: 'prod-surveys.prod.eq.ons.digital'
+      TF_VAR_service_name: 'surveys-static'
+      TF_VAR_container_name: 'eq-survey-runner-static'
+      TF_VAR_application_min_tasks: '3'
+      TF_VAR_container_port: 80
+      TF_VAR_listener_rule_priority: 5
+      TF_VAR_alb_listener_path_pattern: '/s/*'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+      TF_VAR_dns_zone_name: '((prod_dns_zone_name))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+
+          mkdir eq-ecs-deploy
+          tar -xzf source.tar.gz -C eq-ecs-deploy --strip-components=1
+
+          cd eq-ecs-deploy
+          tfenv install
+
+          release_version=$(cat ../../eq-survey-runner-release/tag)
+
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="preprod-ecs-survey-runner-static"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$release_version
+
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-runner'
+        attachments:
+        - pretext: Prod deployment plan failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Deploy Survey Launcher
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'surveys-launch'
+      TF_VAR_container_name: 'go-launch-a-survey'
+      TF_VAR_container_port: 8000
+      TF_VAR_listener_rule_priority: 101
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_task_has_iam_policy: true
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: go-launch-a-survey-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          survey_launcher_tag=$(cat ../go-launch-a-survey-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-launcher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$survey_launcher_tag \
+          -var 'container_environment_variables="{\"name\": \"JWT_ENCRYPTION_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-encryption-sr-public-key.pem\"},{\"name\": \"JWT_SIGNING_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-signing-rrm-private-key.pem\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets\"},{\"name\": \"SURVEY_RUNNER_URL\",\"value\": \"https://preprod-new-surveys.eq.ons.digital\"}"' \
+          -var 'task_iam_policy_json="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Action\":[\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::preprod-secrets*\"}]}"'
+
+  - task: Deploy Schema Validator
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'schema-validator'
+      TF_VAR_container_name: 'eq-schema-validator'
+      TF_VAR_container_port: 5000
+      TF_VAR_listener_rule_priority: 500
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-schema-validator-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          schema_validator_tag=$(cat ../eq-schema-validator-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-ecs-schema-validator"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$schema_validator_tag
+
+  - task: Deploy Author
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'author'
+      TF_VAR_container_name: 'eq-author'
+      TF_VAR_container_port: 3000
+      TF_VAR_listener_rule_priority: 102
+      TF_VAR_healthcheck_path: '/status.json'
+      TF_VAR_healthcheck_grace_period_seconds: 60
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+      TF_VAR_high_cpu_threshold: 80
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          author_tag=$(cat ../eq-author-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-author"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$author_tag \
+          -var 'container_environment_variables="{\"name\": \"REACT_APP_BASE_NAME\", \"value\": \"/eq-author\" },{ \"name\": \"REACT_APP_USE_MOCK_API\", \"value\": \"false\" },{ \"name\": \"REACT_APP_API_URL\", \"value\": \"https://prod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"REACT_APP_PUBLISHER_URL\", \"value\": \"https://prod-publisher.eq.ons.digital/publish\" },{ \"name\": \"REACT_APP_GO_LAUNCH_A_SURVEY_URL\", \"value\": \"https://prod-new-surveys-launch.eq.ons.digital/quick-launch\" },{ \"name\": \"REACT_APP_USE_FULLSTORY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_USE_SENTRY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_ENABLE_AUTH\", \"value\": \"true\" },{ \"name\": \"REACT_APP_FIREBASE_PROJECT_ID\", \"value\": \"((prod_author_firebase_project_id))\" },{ \"name\": \"REACT_APP_FIREBASE_API_KEY\", \"value\": \"((prod_author_firebase_api_key))\" },{ \"name\": \"REACT_APP_FIREBASE_MESSAGING_SENDER_ID\", \"value\": \"((prod_author_firebase_messaging_sender_id))\" }"'
+
+  - task: Deploy Author-Api
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'author-api'
+      TF_VAR_container_name: 'eq-author-api'
+      TF_VAR_container_port: 4000
+      TF_VAR_listener_rule_priority: 103
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-api-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          author_api_tag=$(cat ../eq-author-api-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-author-api"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$author_api_tag \
+          -var 'container_environment_variables="{\"name\": \"DB_CONNECTION_URI\", \"value\": \"((prod_author_database_connection_string))\"}"'
+
+  - task: Deploy Publisher
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'publisher'
+      TF_VAR_container_name: 'eq-publisher'
+      TF_VAR_container_port: 9000
+      TF_VAR_listener_rule_priority: 104
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-publisher-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          publisher_tag=$(cat ../eq-publisher-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-publisher"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$publisher_tag \
+          -var 'container_environment_variables="{ \"name\": \"EQ_AUTHOR_API_URL\", \"value\": \"https://prod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"EQ_SCHEMA_VALIDATOR_URL\", \"value\": \"https://prod-schema-validator.eq.ons.digital/validate\" }"'
+
+  - put: slack-alert
+    params:
+      channel: '#eq-runner'
+      attachments:
+      - pretext: Prod deployment plan ready for review
+        color: good
+        title: Concourse Build $BUILD_ID
+        title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
 - name: Prod-Deployment
   max_in_flight: 1
   plan:

--- a/deploy.yml
+++ b/deploy.yml
@@ -267,6 +267,50 @@ jobs:
     get_params:
       skip_download: true
 
+- name: build-eq-publisher
+  public: true
+  plan:
+  - get: eq-publisher-release
+    params:
+      include_source_tarball: true
+    trigger: true
+  - task: Build Image
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: onsdigital/eq-author-build
+      inputs:
+      - name: eq-publisher-release
+      outputs:
+      - name: compiled-eq-publisher
+      - name: build_args
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          cd eq-publisher-release
+
+          mkdir eq-publisher
+          tar -xzf source.tar.gz -C eq-publisher --strip-components=1
+
+          cd eq-publisher
+          yarn install
+
+          cp -R ../eq-publisher/* ../../compiled-eq-publisher
+
+          eq_publisher_tag=$(cat ../tag)
+          echo "{\"APPLICATION_VERSION\":\""$eq_publisher_tag"\"}" > ../../build_args/args
+          cp ../tag ../../compiled-eq-publisher/.application-version
+  - put: publisher-image
+    params:
+      build: compiled-eq-publisher
+      tag: eq-publisher-release/tag
+      build_args_file: build_args/args
+    get_params:
+      skip_download: true
+
 - name: PreProd-Deploy
   public: true
   max_in_flight: 1

--- a/deploy.yml
+++ b/deploy.yml
@@ -3058,3 +3058,721 @@ jobs:
           color: good
           title: Concourse Build $BUILD_ID
           title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+- name: Author-Prod-Deployment
+  max_in_flight: 1
+  plan:
+  - get: eq-survey-runner-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-author-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-author-api-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-publisher-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-schema-validator-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: go-launch-a-survey-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-dynamodb-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-terraform-ecs-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - get: eq-ecs-deploy-release
+    passed: [Author-Prod-Deployment-Plan]
+    params:
+      include_source_tarball: true
+  - task: Deploy EQ VPC
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_cidr_block: '10.30.20.0/24'
+      TF_VAR_database_cidrs: ["10.30.20.96/28", "10.30.20.112/28", "10.30.20.128/28"]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-vpc
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-vpc" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply
+  - task: Deploy EQ Routing
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_vpc_peer_connection_id: '((prod_vpc_peer_connection_id))'
+      TF_VAR_vpc_peer_cidr_block: '10.30.27.0/24'
+      TF_VAR_public_cidrs: ["10.30.20.144/28","10.30.20.160/28","10.30.20.176/28"]
+      TF_VAR_database_subnet_ids: ((prod_database_subnet_ids))
+      TF_VAR_database_cidrs: ["10.30.20.96/28", "10.30.20.112/28", "10.30.20.128/28"]
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-routing
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-routing" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply
+  - task: Deploy EQ ECS
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_application_cidrs: ["10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
+      TF_VAR_vpc_peer_cidr_block: ["10.30.27.0/24"]
+      TF_VAR_certificate_arn: '((prod_certificate_arn))'
+      TF_VAR_public_subnet_ids: '((prod_public_subnet_ids))'
+      TF_VAR_private_route_table_ids: '((prod_private_route_table_ids))'
+      TF_VAR_ons_access_ips: '((prod_ons_access_ips))'
+      TF_VAR_eq_gateway_ips: '((prod_eq_gateway_ips))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-ecs-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-ecs-release
+
+          mkdir eq-terraform-ecs
+          tar -xzf source.tar.gz -C eq-terraform-ecs --strip-components=1
+
+          cd eq-terraform-ecs
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply
+  - task: Deploy EQ Alerting
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_slack_webhook_path: '((slack_webhook_path))'
+      TF_VAR_slack_channel: 'ops'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-alerting
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-alerting" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply
+  - task: Deploy EQ Survey Runner Database
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_application_cidrs: ["10.30.20.48/28","10.30.20.64/28","10.30.20.80/28","10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
+      TF_VAR_database_name: '((prod_database_name))'
+      TF_VAR_database_user: '((prod_database_user))'
+      TF_VAR_database_password: '((prod_database_password))'
+      TF_VAR_database_instance_class: 'db.r3.xlarge'
+      TF_VAR_database_engine_version: '9.4.15'
+      TF_VAR_database_apply_immediately: false
+      TF_VAR_database_allocated_storage: 640
+      TF_VAR_snapshot_identifier: '((prod_database_snapshot_identifier))'
+      TF_VAR_preferred_maintenance_window: 'wed:03:00-wed:03:30'
+      TF_VAR_db_subnet_group_name: 'prod-eq-rds'
+      TF_VAR_database_identifier: 'prod-digitaleqrds'
+      TF_VAR_rds_security_group_name: 'prod-rds-access'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-database
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-database" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply
+  - task: Deploy EQ Survey Runner DynamoDB
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-dynamodb-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-dynamodb-release
+
+          mkdir eq-terraform-dynamodb
+          tar -xzf source.tar.gz -C eq-terraform-dynamodb --strip-components=1
+
+          cd eq-terraform-dynamodb
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-dynamodb" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply
+  - task: Deploy EQ Survey Runner Queue
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_internet_gateway_id: '((prod_internet_gateway_id))'
+      TF_VAR_queue_cidrs: ["10.30.20.0/27"]
+      TF_VAR_rabbitmq_ips: ["((prod_rabbitmq_ip_prime))","((prod_rabbitmq_ip_failover))"]
+      TF_VAR_application_cidrs: ["10.30.20.48/28","10.30.20.64/28","10.30.20.80/28","10.30.20.192/28","10.30.20.208/28","10.30.20.224/28"]
+      TF_VAR_rsyslogd_server_ip: "10.172.92.242"
+      TF_VAR_logserver_cidr: "10.171.93.21/32"
+      TF_VAR_audit_cidr: "10.172.92.242/32"
+      TF_VAR_sdx_cidrs: ["10.29.1.12/32","10.50.41.20/32","10.50.41.21/32",]
+
+      TF_VAR_aws_key_pair: '((prod_queue_key_pair))'
+      TF_VAR_rabbitmq_instance_type: 't2.medium'
+      TF_VAR_rabbitmq_admin_user: '((prod_rabbitmq_admin_user))'
+      TF_VAR_rabbitmq_admin_password: '((prod_rabbitmq_admin_password))'
+      TF_VAR_rabbitmq_write_user: '((prod_rabbitmq_write_user))'
+      TF_VAR_rabbitmq_write_password: '((prod_rabbitmq_write_password))'
+      TF_VAR_rabbitmq_read_user: '((prod_rabbitmq_read_user))'
+      TF_VAR_rabbitmq_read_password: '((prod_rabbitmq_read_password))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-terraform-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-terraform-release
+
+          mkdir eq-terraform
+          tar -xzf source.tar.gz -C eq-terraform --strip-components=1
+
+          cd eq-terraform/survey-runner-queue
+          tfenv install
+
+          terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=survey-runner-queue" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+        #          terraform plan
+
+  - task: Deploy EQ Survey Runner
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'surveys'
+      TF_VAR_container_name: 'eq-survey-runner'
+      TF_VAR_container_memory_reservation: 512
+      TF_VAR_application_min_tasks: '3'
+      TF_VAR_container_port: 5000
+      TF_VAR_listener_rule_priority: 10
+      TF_VAR_task_has_iam_policy: true
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_dns_zone_name: '((prod_dns_zone_name))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+
+          mkdir eq-ecs-deploy
+          tar -xzf source.tar.gz -C eq-ecs-deploy --strip-components=1
+
+          cd eq-ecs-deploy
+          tfenv install
+
+          release_version=$(cat ../../eq-survey-runner-release/tag)
+
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="ecs-survey-runner"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply \
+          -var container_tag=$release_version \
+          -var 'container_environment_variables="{\"name\": \"EQ_RABBITMQ_HOST\",\"value\": \"((prod_rabbitmq_ip_prime))\"},{\"name\": \"EQ_RABBITMQ_HOST_SECONDARY\",\"value\": \"((prod_rabbitmq_ip_failover))\"},{\"name\": \"EQ_RABBITMQ_QUEUE_NAME\",\"value\": \"submit_q\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_HOST\",\"value\": \"((prod_database_host))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_PORT\",\"value\": \"((prod_database_port))\"},{\"name\": \"EQ_SERVER_SIDE_STORAGE_DATABASE_NAME\",\"value\": \"((prod_database_name))\"},{\"name\": \"EQ_UA_ID\",\"value\": \"((prod_google_analytics_code))\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"prod-secrets-runner\"},{\"name\": \"EQ_SECRETS_FILE\",\"value\": \"../../../secrets/secrets.yml\"},{\"name\": \"EQ_KEYS_FILE\",\"value\": \"../../../secrets/keys.yml\"},{\"name\": \"RESPONDENT_ACCOUNT_URL\",\"value\": \"https://survey.ons.gov.uk/\"},{\"name\": \"EQ_SUBMITTED_RESPONSES_TABLE_NAME\",\"value\": \"prod-submitted-responses\"},{\"name\": \"EQ_QUESTIONNAIRE_STATE_TABLE_NAME\",\"value\": \"prod-questionnaire-state\"},{\"name\": \"EQ_SESSION_TABLE_NAME\",\"value\": \"prod-eq-session\"},{\"name\": \"EQ_USED_JTI_CLAIM_TABLE_NAME\",\"value\": \"prod-used-jti-claim\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_USED_JTI_CLAIM_DYNAMO_WRITE\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_READ\",\"value\": \"True\"},{\"name\": \"EQ_SESSION_DYNAMO_WRITE\",\"value\": \"False\"}"' \
+          -var 'task_iam_policy_json="{\"Version\": \"2012-10-17\",\"Statement\": [{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\": \"arn:aws:s3:::*\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\"],\"Resource\": \"((prod_submitted_responses_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_questionnaire_state_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\",\"dynamodb:GetItem\",\"dynamodb:DeleteItem\"],\"Resource\": \"((prod_eq_session_table_arn))\"},{\"Sid\": \"\",\"Effect\": \"Allow\",\"Action\": [\"dynamodb:PutItem\"],\"Resource\": \"((prod_used_jti_claim_table_arn))\"}]}"'
+  - task: Deploy EQ Survey Runner Static
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_dns_record_name: 'prod-surveys.prod.eq.ons.digital'
+      TF_VAR_service_name: 'surveys-static'
+      TF_VAR_container_name: 'eq-survey-runner-static'
+      TF_VAR_application_min_tasks: '3'
+      TF_VAR_container_port: 80
+      TF_VAR_listener_rule_priority: 5
+      TF_VAR_alb_listener_path_pattern: '/s/*'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+      TF_VAR_dns_zone_name: '((prod_dns_zone_name))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+
+          mkdir eq-ecs-deploy
+          tar -xzf source.tar.gz -C eq-ecs-deploy --strip-components=1
+
+          cd eq-ecs-deploy
+          tfenv install
+
+          release_version=$(cat ../../eq-survey-runner-release/tag)
+
+          terraform init -backend-config="bucket="jenkins-ci-production-terraform-state"" -backend-config="key="preprod-ecs-survey-runner-static"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform apply \
+          -var container_tag=$release_version
+
+  - task: Deploy Survey Launcher
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{preprod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{preprod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'surveys-launch'
+      TF_VAR_container_name: 'go-launch-a-survey'
+      TF_VAR_container_port: 8000
+      TF_VAR_listener_rule_priority: 101
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_task_has_iam_policy: true
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: go-launch-a-survey-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          survey_launcher_tag=$(cat ../go-launch-a-survey-release/tag)
+
+          terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-launcher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$survey_launcher_tag \
+          -var 'container_environment_variables="{\"name\": \"JWT_ENCRYPTION_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-encryption-sr-public-key.pem\"},{\"name\": \"JWT_SIGNING_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-signing-rrm-private-key.pem\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets\"},{\"name\": \"SURVEY_RUNNER_URL\",\"value\": \"https://preprod-new-surveys.eq.ons.digital\"}"' \
+          -var 'task_iam_policy_json="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Action\":[\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::preprod-secrets*\"}]}"'
+
+  - task: Deploy Schema Validator
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'schema-validator'
+      TF_VAR_container_name: 'eq-schema-validator'
+      TF_VAR_container_port: 5000
+      TF_VAR_listener_rule_priority: 500
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-schema-validator-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          schema_validator_tag=$(cat ../eq-schema-validator-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-ecs-schema-validator"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$schema_validator_tag
+
+  - task: Deploy Author
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'author'
+      TF_VAR_container_name: 'eq-author'
+      TF_VAR_container_port: 3000
+      TF_VAR_listener_rule_priority: 102
+      TF_VAR_healthcheck_path: '/status.json'
+      TF_VAR_healthcheck_grace_period_seconds: 60
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+      TF_VAR_high_cpu_threshold: 80
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          author_tag=$(cat ../eq-author-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-author"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$author_tag \
+          -var 'container_environment_variables="{\"name\": \"REACT_APP_BASE_NAME\", \"value\": \"/eq-author\" },{ \"name\": \"REACT_APP_USE_MOCK_API\", \"value\": \"false\" },{ \"name\": \"REACT_APP_API_URL\", \"value\": \"https://prod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"REACT_APP_PUBLISHER_URL\", \"value\": \"https://prod-publisher.eq.ons.digital/publish\" },{ \"name\": \"REACT_APP_GO_LAUNCH_A_SURVEY_URL\", \"value\": \"https://prod-new-surveys-launch.eq.ons.digital/quick-launch\" },{ \"name\": \"REACT_APP_USE_FULLSTORY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_USE_SENTRY\", \"value\": \"true\" },{ \"name\": \"REACT_APP_ENABLE_AUTH\", \"value\": \"true\" },{ \"name\": \"REACT_APP_FIREBASE_PROJECT_ID\", \"value\": \"((prod_author_firebase_project_id))\" },{ \"name\": \"REACT_APP_FIREBASE_API_KEY\", \"value\": \"((prod_author_firebase_api_key))\" },{ \"name\": \"REACT_APP_FIREBASE_MESSAGING_SENDER_ID\", \"value\": \"((prod_author_firebase_messaging_sender_id))\" }"'
+
+  - task: Deploy Author-Api
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'author-api'
+      TF_VAR_container_name: 'eq-author-api'
+      TF_VAR_container_port: 4000
+      TF_VAR_listener_rule_priority: 103
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-api-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          author_api_tag=$(cat ../eq-author-api-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-author-api"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$author_api_tag \
+          -var 'container_environment_variables="{\"name\": \"DB_CONNECTION_URI\", \"value\": \"((prod_author_database_connection_string))\"}"'
+
+  - task: Deploy Publisher
+    params:
+      TF_VAR_env: 'prod'
+      TF_VAR_aws_account_id: '((prod_aws_account_id))'
+      TF_VAR_aws_assume_role_arn: '((prod_aws_assume_role_arn))'
+      TF_VAR_vpc_id: '((prod_vpc_id))'
+      TF_VAR_ecs_cluster_name: 'prod-eq'
+      TF_VAR_docker_registry: {{docker_registry}}
+      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_service_name: 'publisher'
+      TF_VAR_container_name: 'eq-publisher'
+      TF_VAR_container_port: 9000
+      TF_VAR_listener_rule_priority: 104
+      TF_VAR_healthcheck_path: '/status'
+      TF_VAR_slack_alert_sns_arn: '((prod_slack_alert_sns_arn))'
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-publisher-release
+      - name: eq-ecs-deploy-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          cd eq-ecs-deploy-release
+          tfenv install
+
+          publisher_tag=$(cat ../eq-publisher-release/tag)
+
+          terraform init -backend-config="bucket="concourse-prod-terraform-state"" -backend-config="key="prod-publisher"" -backend-config="role_arn="((prod_aws_assume_role_arn))""
+          terraform plan \
+          -var container_tag=$publisher_tag \
+          -var 'container_environment_variables="{ \"name\": \"EQ_AUTHOR_API_URL\", \"value\": \"https://prod-author-api.eq.ons.digital/graphql\" },{ \"name\": \"EQ_SCHEMA_VALIDATOR_URL\", \"value\": \"https://prod-schema-validator.eq.ons.digital/validate\" }"'
+
+  - task: Wait for Deployed EQ Survey Runner
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-survey-runner-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          survey_runner_tag=$(cat eq-survey-runner-release/tag)
+          while [[ "$(curl -s https://prod-surveys.prod.eq.ons.digital/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
+
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-runner'
+        attachments:
+        - pretext: Prod deployment failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Wait for Deployed Author API
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-api-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          author_api_tag=$(cat eq-author-api-release/tag)
+          while [[ "$(curl -s https://prod-author-api.eq.ons.digital/status)" != *"$author_api_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+        - pretext: Prod Author API Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Wait for Deployed Author
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-author-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          author_tag=$(cat eq-author-release/tag)
+          while [[ "$(curl -s https://prod-author.eq.ons.digital/status.json)" != *"$author_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+        - pretext: Prod Author Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - task: Wait for Deployed Publisher
+    timeout: 10m
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: onsdigital/eq-terraform-build
+      inputs:
+      - name: eq-publisher-release
+      run:
+        path: bash
+        args:
+        - -exc
+        - |
+          publisher_tag=$(cat eq-publisher-release/tag)
+          while [[ "$(curl -s https://prod-publisher.eq.ons.digital/status)" != *"$publisher_tag"* ]]; do sleep 5; done
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#eq-author'
+        attachments:
+        - pretext: Prod Publisher Deploy Failed
+          color: danger
+          title: Concourse Build $BUILD_ID
+          title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - put: slack-alert
+    params:
+      channel: '#eq-author'
+      attachments:
+      - pretext: Prod deployment successful
+        color: good
+        title: Concourse Build $BUILD_ID
+        title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID
+
+  - put: slack-alert
+    params:
+      channel: '#eq-author'
+      attachments:
+      - pretext: Prod deployment successful
+        color: good
+        title: Concourse Build $BUILD_ID
+        title_link: http://concourse.dev.eq.ons.digital/builds/$BUILD_ID

--- a/deploy.yml
+++ b/deploy.yml
@@ -94,7 +94,7 @@ resources:
     release: true
     pre_release: true
 
-- name: eq-survey-launcher-release
+- name: go-launch-a-survey-release
   type: github-release
   source:
     owner: ONSdigital
@@ -123,10 +123,10 @@ resources:
   source:
     repository: ((docker_registry))/eq-schema-validator
 
-- name: survey-launcher-image
+- name: go-launch-a-survey-image
   type: docker-image
   source:
-    repository: ((docker_registry))/eq-survey-launcher
+    repository: ((docker_registry))/go-launch-a-survey
 
 jobs:
 - name: build-eq-survey-runner
@@ -351,6 +351,51 @@ jobs:
     params:
       build: compiled-eq-schema-validator
       tag: eq-schema-validator-release/tag
+    get_params:
+      skip_download: true
+
+- name: build-go-launch-a-survey
+  public: true
+  plan:
+  - get: go-launch-a-survey-release
+    params:
+      include_source_tarball: true
+    trigger: true
+  - task: Build Image
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: onsdigital/eq-golang-build
+      inputs:
+      - name: go-launch-a-survey-release
+      outputs:
+      - name: compiled-go-launch-a-survey
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          service docker start
+
+          build_dir=$(pwd)
+          export GOPATH=$HOME/gopath
+          export PATH=$HOME/gopath/bin:$PATH
+          mkdir -p $HOME/gopath/src/github.com/ONSdigital/go-launch-a-survey
+          cp -R go-launch-a-survey-release/ $HOME/gopath/src/github.com/ONSdigital/
+          cd $HOME/gopath/src/github.com/ONSdigital/go-launch-a-survey
+
+          go get -u github.com/golang/dep/cmd/dep
+          dep ensure
+          docker run --rm -v $(pwd):/src centurylink/golang-builder
+
+          service docker stop
+
+          cp -R . $build_dir/go-launch-a-survey-compiled
+  - put: go-launch-a-survey-image
+    params:
+      build: compiled-go-launch-a-survey
+      tag: go-launch-a-survey-release/tag
     get_params:
       skip_download: true
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -103,6 +103,31 @@ resources:
     release: true
     pre_release: true
 
+- name: author-image
+  type: docker-image
+  source:
+    repository: ((docker_registry))/eq-author
+
+- name: author-api-image
+  type: docker-image
+  source:
+    repository: ((docker_registry))/eq-author
+
+- name: publisher-image
+  type: docker-image
+  source:
+    repository: ((docker_registry))/eq-publisher
+
+- name: schema-validator-image
+  type: docker-image
+  source:
+    repository: ((docker_registry))/eq-schema-validator
+
+- name: survey-launcher-image
+  type: docker-image
+  source:
+    repository: ((docker_registry))/eq-survey-launcher
+
 jobs:
 - name: build-eq-survey-runner
   public: true
@@ -191,12 +216,56 @@ jobs:
               echo "{\"APPLICATION_VERSION\":\""$eq_author_tag"\"}" > ../../build_args/args
               cp ../tag ../../compiled-eq-author/.application-version
     - put: author-image
-        params:
-          build: compiled-eq-author
-          tag: eq-author-release/tag
-          build_args_file: build_args/args
-        get_params:
-          skip_download: true
+      params:
+        build: compiled-eq-author
+        tag: eq-author-release/tag
+        build_args_file: build_args/args
+      get_params:
+        skip_download: true
+
+- name: build-eq-author-api
+  public: true
+  plan:
+  - get: eq-author-api-release
+    params:
+      include_source_tarball: true
+    trigger: true
+  - task: Build Image
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: onsdigital/eq-author-build
+      inputs:
+      - name: eq-author-api-release
+      outputs:
+      - name: compiled-eq-author-api
+      - name: build_args
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          cd eq-author-api-release
+
+          mkdir eq-author-api
+          tar -xzf source.tar.gz -C eq-author-api --strip-components=1
+
+          cd eq-author-api
+          yarn install
+
+          cp -R ../eq-author-api/* ../../compiled-eq-author-api
+
+          eq_author_api_tag=$(cat ../tag)
+          echo "{\"APPLICATION_VERSION\":\""$eq_author_api_tag"\"}" > ../../build_args/args
+          cp ../tag ../../compiled-eq-author-api/.application-version
+  - put: author-api-image
+    params:
+      build: compiled-eq-author-api
+      tag: eq-author-api-release/tag
+      build_args_file: build_args/args
+    get_params:
+      skip_download: true
 
 - name: PreProd-Deploy
   public: true


### PR DESCRIPTION
## Description
This PR extends the existing deployment pipeline with tasks to build and deploy author services.

The motivation behind this PR is to move away from automated deployments to Pre-Prod on merge to master and be able to plan and stage a number of changes into a tagged release.