### PR TITLE
Set to current prod values and restrict deployments to V2

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -12,6 +12,7 @@ resources:
     owner: ONSdigital
     repository: eq-survey-runner
     access_token: ((github_access_token))
+    tag_filter: "v2.*"
 
 - name: eq-author-app-release
   type: github-release
@@ -938,12 +939,12 @@ jobs:
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
-      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
-      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_aws_alb_arn: {{prod_internal_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_internal_aws_alb_listener_arn}}
       TF_VAR_service_name: 'surveys'
       TF_VAR_container_name: 'eq-survey-runner'
       TF_VAR_container_memory_reservation: 512
-      TF_VAR_application_min_tasks: '3'
+      TF_VAR_application_min_tasks: '6'
       TF_VAR_container_port: 5000
       TF_VAR_listener_rule_priority: 10
       TF_VAR_task_has_iam_policy: true
@@ -989,8 +990,8 @@ jobs:
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
-      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
-      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_aws_alb_arn: {{prod_internal_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_internal_aws_alb_listener_arn}}
       TF_VAR_dns_record_name: 'prod-surveys.prod.eq.ons.digital'
       TF_VAR_service_name: 'surveys-static'
       TF_VAR_container_name: 'eq-survey-runner-static'
@@ -1173,7 +1174,7 @@ jobs:
           tfenv install
 
           terraform init -backend-config "bucket=jenkins-ci-production-terraform-state" -backend-config "key=eq-terraform-ecs" -backend-config="role_arn="((prod_aws_assume_role_arn))""
-          terraform plan
+          terraform apply
 
   - task: Deploy EQ Alerting
     params:
@@ -1331,12 +1332,12 @@ jobs:
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
-      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
-      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_aws_alb_arn: {{prod_internal_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_internal_aws_alb_listener_arn}}
       TF_VAR_service_name: 'surveys'
       TF_VAR_container_name: 'eq-survey-runner'
       TF_VAR_container_memory_reservation: 512
-      TF_VAR_application_min_tasks: '3'
+      TF_VAR_application_min_tasks: '6'
       TF_VAR_container_port: 5000
       TF_VAR_listener_rule_priority: 10
       TF_VAR_task_has_iam_policy: true
@@ -1381,8 +1382,8 @@ jobs:
       TF_VAR_vpc_id: '((prod_vpc_id))'
       TF_VAR_ecs_cluster_name: 'prod-eq'
       TF_VAR_docker_registry: {{docker_registry}}
-      TF_VAR_aws_alb_arn: {{prod_aws_alb_arn}}
-      TF_VAR_aws_alb_listener_arn: {{prod_aws_alb_listener_arn}}
+      TF_VAR_aws_alb_arn: {{prod_internal_aws_alb_arn}}
+      TF_VAR_aws_alb_listener_arn: {{prod_internal_aws_alb_listener_arn}}
       TF_VAR_dns_record_name: 'prod-surveys.prod.eq.ons.digital'
       TF_VAR_service_name: 'surveys-static'
       TF_VAR_container_name: 'eq-survey-runner-static'
@@ -1437,7 +1438,7 @@ jobs:
         - -exc
         - |
           survey_runner_tag=$(cat eq-survey-runner-release/tag)
-          while [[ "$(curl -s https://prod-surveys.prod.eq.ons.digital/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
+          while [[ "$(curl -s https://eq.ons.gov.uk/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
 
     on_failure:
       put: slack-alert

--- a/secrets.yml.example
+++ b/secrets.yml.example
@@ -84,8 +84,8 @@ prod_aws_account_id:
 prod_aws_assume_role_arn:
 prod_ons_access_ips:
 prod_vpc_id:
-prod_aws_alb_arn:
-prod_aws_alb_listener_arn:
+prod_internal_aws_alb_arn:
+prod_internal_aws_alb_listener_arn:
 prod_slack_alert_sns_arn:
 prod_database_host:
 prod_database_port:


### PR DESCRIPTION
This PR contains changes to the pipeline following the switch to ECS in Production.
This also restricts the pipeline to only deploy V2 runner releases