### PR TITLE
Fix survey-runner url on health check.

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -511,7 +511,7 @@ jobs:
         - -exc
         - |
           survey_runner_tag=$(cat eq-survey-runner/.git/HEAD | xargs echo -n)
-          while [[ "$(curl -s https://staging-new-surveys.dev.eq.ons.digital/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
+          while [[ "$(curl -s https://staging-surveys.dev.eq.ons.digital/status)" != *"$survey_runner_tag"* ]]; do sleep 5; done
     on_failure:
       put: slack-alert
       params:


### PR DESCRIPTION
Staging deployment is failing because the url for survey runner has changed to drop the `new`.
The concourse pipeline is attempting to wait for a response from an invalid url.
Confirmed that the expected endpoint can be reached when new is dropped from the URL.