### PR TITLE
Fix release tag filtering

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -4,53 +4,60 @@ resource_types:
   source:
     repository: cfcommunity/slack-notification-resource
     tag: latest
+    
+- name: github-release-latest
+    type: docker-image
+    source:
+      repository: concourse/github-release-resource
+      tag: 1.1.0
 
 resources:
 - name: eq-survey-runner-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-survey-runner
     access_token: ((github_access_token))
     tag_filter: "v2.*"
+    order_by: time
 
 - name: eq-author-app-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-author-app
     access_token: ((github_access_token))
 
 - name: eq-schema-validator-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-schema-validator
     access_token: ((github_access_token))
 
 - name: eq-terraform-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-terraform
     access_token: ((github_access_token))
 
 - name: eq-terraform-dynamodb-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-terraform-dynamodb
     access_token: ((github_access_token))
 
 - name: eq-terraform-ecs-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-terraform-ecs
     access_token: ((github_access_token))
 
 - name: eq-ecs-deploy-release
-  type: github-release
+  type: github-release-latest
   source:
     owner: ONSdigital
     repository: eq-ecs-deploy


### PR DESCRIPTION
There is an issue with the version of `github-release` currently being used in that it would pick up releases of a lower semantic version.

Ordering by time is only in the latest github-release resource

This PR forces concourse to use the latest version of the resource so the release resource is able to pick up lower semver versions

Screenshot showing older versions being picked up
![Screenshot 2019-03-18 at 11 38 00](https://user-images.githubusercontent.com/7594012/54527608-5274da80-4972-11e9-8660-64ff8b88d14f.png)


PR that fixes issue https://github.com/concourse/github-release-resource/pull/77
Released in https://github.com/concourse/github-release-resource/releases/tag/v1.1.0