### PR TITLE
Replace old survey launcher

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -745,7 +745,7 @@ jobs:
   - get: eq-ecs-deploy
   - task: Deploy Survey Launcher
     params:
-      TF_VAR_env: 'preprod-new'
+      TF_VAR_env: 'preprod'
       TF_VAR_aws_account_id: '((preprod_aws_account_id))'
       TF_VAR_aws_assume_role_arn: '((preprod_aws_assume_role_arn))'
       TF_VAR_vpc_id: '((preprod_vpc_id))'
@@ -782,7 +782,7 @@ jobs:
           terraform init -backend-config="bucket="concourse-preprod-terraform-state"" -backend-config="key="preprod-ecs-launcher"" -backend-config="role_arn="((preprod_aws_assume_role_arn))""
           terraform apply \
           -var container_tag=$survey_launcher_tag \
-          -var 'container_environment_variables="{\"name\": \"JWT_ENCRYPTION_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-encryption-sr-public-key.pem\"},{\"name\": \"JWT_SIGNING_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-signing-launcher-private-key.pem\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets\"},{\"name\": \"SURVEY_RUNNER_URL\",\"value\": \"https://eqtest.onsdigital.uk\"},{\"name\": \"SCHEMA_VALIDATOR_URL\",\"value\": \"https://preprod-schema-validator.eq.ons.digital\"}"' \
+          -var 'container_environment_variables="{\"name\": \"JWT_ENCRYPTION_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-encryption-sr-public-key.pem\"},{\"name\": \"JWT_SIGNING_KEY_PATH\",\"value\": \"/secrets/sdc-user-authentication-signing-launcher-private-key.pem\"},{\"name\": \"SECRETS_S3_BUCKET\",\"value\": \"preprod-secrets\"},{\"name\": \"SURVEY_RUNNER_URL\",\"value\": \"https://eq.onsdigital.uk\"},{\"name\": \"SCHEMA_VALIDATOR_URL\",\"value\": \"https://preprod-schema-validator.eq.ons.digital\"}"' \
           -var 'task_iam_policy_json="{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Action\":[\"s3:ListObjects\",\"s3:ListBucket\",\"s3:GetObject\"],\"Resource\":\"arn:aws:s3:::preprod-secrets*\"}]}"'
 
   - task: Deploy Address Lookup API


### PR DESCRIPTION
There are currently two instances of survey launcher deployed in pre-prod.
This PR changes the name of the deployed launcher service to replace the old one and updates the survey runner url to no longer point at the test domain name.