### PR TITLE
Update listener rules to remove the host headers.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -1726,6 +1726,7 @@ jobs:
         TF_VAR_docker_registry: {{docker_registry}}
         TF_VAR_aws_alb_arn: {{preprod_author_aws_external_alb_arn}}
         TF_VAR_aws_alb_listener_arn: {{preprod_author_aws_alb_external_listener_arn}}
+        TF_VAR_aws_alb_use_host_header: false
         TF_VAR_dns_record_name: 'preprod-author.eq.ons.digital'
         TF_VAR_service_name: 'author-api'
         TF_VAR_container_name: 'eq-author-api'
@@ -1780,10 +1781,11 @@ jobs:
         TF_VAR_docker_registry: {{docker_registry}}
         TF_VAR_aws_alb_arn: {{preprod_author_aws_external_alb_arn}}
         TF_VAR_aws_alb_listener_arn: {{preprod_author_aws_alb_external_listener_arn}}
+        TF_VAR_aws_alb_use_host_header: false
         TF_VAR_service_name: 'author'
         TF_VAR_container_name: 'eq-author'
         TF_VAR_container_port: 3000
-        TF_VAR_listener_rule_priority: 400
+        TF_VAR_listener_rule_priority: 900
         TF_VAR_healthcheck_path: '/status.json'
         TF_VAR_healthcheck_grace_period_seconds: 120
         TF_VAR_slack_alert_sns_arn: '((preprod_slack_alert_sns_arn))'
@@ -2334,6 +2336,7 @@ jobs:
         TF_VAR_docker_registry: {{docker_registry}}
         TF_VAR_aws_alb_arn: {{prod_author_aws_external_alb_arn}}
         TF_VAR_aws_alb_listener_arn: {{prod_author_aws_alb_external_listener_arn}}
+        TF_VAR_aws_alb_use_host_header: false
         TF_VAR_dns_record_name: 'prod-author.prod.eq.ons.digital'
         TF_VAR_service_name: 'author-api'
         TF_VAR_container_name: 'eq-author-api'
@@ -2389,10 +2392,11 @@ jobs:
         TF_VAR_docker_registry: {{docker_registry}}
         TF_VAR_aws_alb_arn: {{prod_author_aws_external_alb_arn}}
         TF_VAR_aws_alb_listener_arn: {{prod_author_aws_alb_external_listener_arn}}
+        TF_VAR_aws_alb_use_host_header: false
         TF_VAR_service_name: 'author'
         TF_VAR_container_name: 'eq-author'
         TF_VAR_container_port: 3000
-        TF_VAR_listener_rule_priority: 400
+        TF_VAR_listener_rule_priority: 900
         TF_VAR_healthcheck_path: '/status.json'
         TF_VAR_healthcheck_grace_period_seconds: 120
         TF_VAR_dns_zone_name: '((prod_dns_zone_name))'
@@ -2833,6 +2837,7 @@ jobs:
         TF_VAR_docker_registry: {{docker_registry}}
         TF_VAR_aws_alb_arn: {{prod_author_aws_external_alb_arn}}
         TF_VAR_aws_alb_listener_arn: {{prod_author_aws_alb_external_listener_arn}}
+        TF_VAR_aws_alb_use_host_header: false
         TF_VAR_dns_record_name: 'prod-author.prod.eq.ons.digital'
         TF_VAR_service_name: 'author-api'
         TF_VAR_container_name: 'eq-author-api'
@@ -2888,10 +2893,11 @@ jobs:
         TF_VAR_docker_registry: {{docker_registry}}
         TF_VAR_aws_alb_arn: {{prod_author_aws_external_alb_arn}}
         TF_VAR_aws_alb_listener_arn: {{prod_author_aws_alb_external_listener_arn}}
+        TF_VAR_aws_alb_use_host_header: false
         TF_VAR_service_name: 'author'
         TF_VAR_container_name: 'eq-author'
         TF_VAR_container_port: 3000
-        TF_VAR_listener_rule_priority: 400
+        TF_VAR_listener_rule_priority: 900
         TF_VAR_healthcheck_path: '/status.json'
         TF_VAR_healthcheck_grace_period_seconds: 120
         TF_VAR_dns_zone_name: '((prod_dns_zone_name))'


### PR DESCRIPTION
## What is the context of this PR?
This change adds an additional flag to both eq-author-api and eq-author deploy tasks to prevent filtering on the host headers in the ALB listener rules.

This change is intended to fix the issue of traffic routing to author's short url not being routed to the author target group in both pre-prod and prod.

## How to test?
Because the short URL is only set up to route traffic to the production load balancer this change can only really be tested when deployed into production.

But a sanity check to ensure the variables are set correctly should be carried out before merging. The concourse pipeline will need to be redeployed once this PR gets merged to test the changes.