### PR TITLE
Revert "Add additional variables for author api secrets bucket."

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -488,9 +488,7 @@ jobs:
             -var author_gtm_id="((author_google_tag_manager_id))" \
             -var author_gtm_env_id="((staging_author_google_tag_manager_environment_id))" \
             -var author_sentry_dsn="((author_sentry_dsn))" \
-            -var author_api_enable_import="true" \
-            -var author_secrets_bucket_name="((staging_author_secrets_bucket_name))" \
-            -var author_firebase_service_account_key="((author_firebase_service_account_key))"
+            -var author_api_enable_import="true"
     on_failure:
       put: slack-alert
       params:


### PR DESCRIPTION
## What is the context of this PR?
The pipeline was recently modified to pass in additional variables to the author-api task so that it could sync the secrets for token verification from S3. A different approach to token verification means that these additional variables are no longer required.

This PR reverts the change to the pipeline.

## Related
- https://github.com/ONSdigital/eq-author-terraform/pull/18